### PR TITLE
Divide alpha by n in LRN layer

### DIFF
--- a/keras/caffe/extra_layers.py
+++ b/keras/caffe/extra_layers.py
@@ -28,7 +28,7 @@ class LRN2D(Layer):
         input_sqr = T.set_subtensor(extra_channels[:, half_n:half_n+ch, :, :],input_sqr)
         scale = self.k
         for i in range(self.n):
-            scale += self.alpha * input_sqr[:, i:i+ch, :, :]
+            scale += self.alpha / self.n * input_sqr[:, i:i+ch, :, :]
         scale = scale ** self.beta
         return X / scale
 


### PR DESCRIPTION
The implementation of the local response normalization layer seems to be wrong. In Caffe, [alpha is divided by n](https://github.com/BVLC/caffe/blob/master/src/caffe/layers/lrn_layer.cpp#L120). This pull request fixes the bug.
